### PR TITLE
Feat/add password toggle

### DIFF
--- a/client/src/components/Signin.jsx
+++ b/client/src/components/Signin.jsx
@@ -6,6 +6,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { login } from "../redux/action.js"
 import toast from "react-hot-toast"
+import { GoEye,GoEyeClosed } from "react-icons/go";
 
 export default function Signin() {
   const refForm = useRef();
@@ -16,6 +17,7 @@ export default function Signin() {
 
   const [email,setEmail] = useState("");
   const [password,setPassword] = useState("");
+  const [showPassword,setShowPassword] = useState(false);
 
   const handleLogin = (e) => {
     e.preventDefault();
@@ -105,16 +107,27 @@ export default function Signin() {
                   <li className="d-block mx-auto">
                     <label for="password" className="text-white p-2">🔐Password:</label>
                     <br></br>
-                    <input style={{ width: "18rem" }}
-                      className={`rounded-pill bg-${theme} ${theme === "dark" ? "text-light" : "text-dark"}`}
-                      type="text"
-                      placeholder="Password"
-                      name="Type Password"
-                      id="password"
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      required
-                    />
+                    <div className="d-flex relative align-items-center">
+                      <input style={{ width: "18rem" }}
+                        className={`rounded-pill bg-${theme} ${theme === "dark" ? "text-light" : "text-dark"}`}
+                        type={`${showPassword ? "text" : "password"}`}
+                        placeholder="Password"
+                        name="Type Password"
+                        id="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        required
+                      />
+                      {
+                        showPassword ?
+                        <GoEyeClosed className="fs-4 password-icon" onClick={() => setShowPassword(false)} 
+                        color={`${theme === "dark" ? "white" : "black"}`}
+                        />:
+                        <GoEye className="fs-4 password-icon" onClick={() => setShowPassword(true)}
+                        color={`${theme === "dark" ? "white" : "black"}`}
+                      />
+                    }
+                  </div>
                   </li>
                   {/* <li>
                     <textarea

--- a/client/src/components/Signup.jsx
+++ b/client/src/components/Signup.jsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import toast from 'react-hot-toast'
 import { signup } from "../redux/action.js";
+import { GoEye,GoEyeClosed } from "react-icons/go";
 
 export default function SignUp() {
   const refForm = useRef();
@@ -28,6 +29,9 @@ export default function SignUp() {
     profileImage: null,
     profileImagePreview: null, 
   });
+
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
@@ -150,9 +154,10 @@ export default function SignUp() {
 
                   <li>
                   <label for="passcode" className="text-white p-2">🔐Password:</label>
+                  <div className="d-flex relative align-items-center">
                     <input
                       className={`w-100 p-2 rounded-pill bg-${theme} ${theme === 'dark' ? 'text-white' : 'text-dark'}`}
-                      type="password"
+                      type={`${showPassword ? "text" : "password"}`}
                       name="password"
                       id="passcode"
                       placeholder="Password"
@@ -160,13 +165,24 @@ export default function SignUp() {
                       onChange={handleInputChange}
                       required
                     />
+                      {
+                        showPassword ?
+                        <GoEyeClosed className="fs-4 password-icon" onClick={() => setShowPassword(false)} 
+                        color={`${theme === "dark" ? "white" : "black"}`}
+                        />:
+                        <GoEye className="fs-4 password-icon" onClick={() => setShowPassword(true)}
+                        color={`${theme === "dark" ? "white" : "black"}`}
+                      />
+                      }
+                    </div>
                   </li>
 
                   <li>
                   <label for="confirm_password" className="text-white p-2">🔐Confirm Password:</label>
+                  <div className="d-flex relative align-items-center">
                     <input
                       className={`w-100 p-2 rounded-pill bg-${theme} ${theme === 'dark' ? 'text-white' : 'text-dark'}`}
-                      type="password"
+                      type={`${showConfirmPassword ? "text" : "password"}`}
                       id="confirm_password"
                       name="confirmPassword"
                       placeholder="Confirm Password"
@@ -174,6 +190,16 @@ export default function SignUp() {
                       onChange={handleInputChange}
                       required
                     />
+                      {
+                        showConfirmPassword ?
+                        <GoEyeClosed className="fs-4 password-icon" onClick={() => setShowConfirmPassword(false)} 
+                        color={`${theme === "dark" ? "white" : "black"}`}
+                        />:
+                        <GoEye className="fs-4 password-icon" onClick={() => setShowConfirmPassword(true)}
+                        color={`${theme === "dark" ? "white" : "black"}`}
+                      />
+                      }
+                  </div>
                   </li>
 
                   <li>

--- a/client/src/components/styles/signin.css
+++ b/client/src/components/styles/signin.css
@@ -1,73 +1,81 @@
 .contact-form {
-    width: 100%;
-    margin-top: 20px;
-  }
-  
-  ul {
-    padding: 0;
-    margin: 0;
-  }
-  li {
-    padding: 0;
-    margin: 0;
-    list-style: none;
-    margin-bottom: 10px;
-    overflow: hidden;
-    display: block;
-    position: relative;
-    clear: both;
-  }
-  
-  .half {
-    width: 49%;
-    margin-left: 2%;
-    float: left;
-    clear: none;
-  }
-  
-  .half:first-child {
-    margin-left: 0;
-  }
-  
-  input[type="text"],
-  input[type="email"] {
-    width: 100%;
-    border: 0;
-  
-    background-color: aliceblue;
-    height: 50px;
-    font-size: 16px;
-    color: #000;
-    padding: 0 20px;
-    box-sizing: border-box;
-  }
-  
-  textarea {
-    width: 100%;
-    border: 0;
-    background-color: aliceblue;
-    height: 50px;
-    font-size: 16px;
-    color: #000;
-    padding: 0 20px;
-    box-sizing: border-box;
-    min-height: 150px;
-  }
-  
-  .flat-button {
-    color: #fff;
-    background: 0 0;
-    font: 11px;
-    letter-spacing: 3px;
-    text-decoration: none;
-    padding: 8px 10px;
-    border: 1px solid #ffd700;
-    float: right;
-  }
-  
-  .mail {
-    font-size: 16px;
-    display: block;
-    padding-top: 20px;
-    color: #ffd700;
-  }
+  width: 100%;
+  margin-top: 20px;
+}
+
+ul {
+  padding: 0;
+  margin: 0;
+}
+
+li {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  margin-bottom: 10px;
+  overflow: hidden;
+  display: block;
+  position: relative;
+  clear: both;
+}
+
+.half {
+  width: 49%;
+  margin-left: 2%;
+  float: left;
+  clear: none;
+}
+
+.half:first-child {
+  margin-left: 0;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="password"] {
+  width: 100%;
+  border: 0;
+
+  background-color: aliceblue;
+  height: 50px;
+  font-size: 16px;
+  color: #000;
+  padding: 0 20px;
+  box-sizing: border-box;
+}
+
+.password-icon {
+  position: absolute;
+  right: 10px;
+  cursor: pointer;
+}
+
+textarea {
+  width: 100%;
+  border: 0;
+  background-color: aliceblue;
+  height: 50px;
+  font-size: 16px;
+  color: #000;
+  padding: 0 20px;
+  box-sizing: border-box;
+  min-height: 150px;
+}
+
+.flat-button {
+  color: #fff;
+  background: 0 0;
+  font: 11px;
+  letter-spacing: 3px;
+  text-decoration: none;
+  padding: 8px 10px;
+  border: 1px solid #ffd700;
+  float: right;
+}
+
+.mail {
+  font-size: 16px;
+  display: block;
+  padding-top: 20px;
+  color: #ffd700;
+}


### PR DESCRIPTION
This pull request focuses on enhancing the user experience for the Signin and Signup components by adding functionality to toggle password visibility. Additionally, some minor CSS adjustments were made to support these changes.

Closes #33 

### Enhancements to Signin and Signup components:

* [`client/src/components/Signin.jsx`](diffhunk://#diff-818ae7d5d4aaf4da7e032707c93655a24994c8e4040218490dac1581e2940b62R9): Added state management for toggling password visibility and incorporated `GoEye` and `GoEyeClosed` icons for the password input field. 
* [`client/src/components/Signup.jsx`](diffhunk://#diff-650c27a3769b3132287e73e8b28015c4c3d759dc65bd38c018d64ec1a099ad24R10): Added state management for toggling password and confirm password visibility, and incorporated `GoEye` and `GoEyeClosed` icons for the respective input fields. 

### CSS adjustments:

* [`client/src/components/styles/signin.css`](diffhunk://#diff-d8f6af26e54d953741d6fe691102c3e4c289f4a16e734c87347f90a2f2fe5961R47-R52): Added styles for the new password visibility toggle icons.

### Video

https://github.com/user-attachments/assets/00dd97c2-48a8-40b8-924e-024a2559ca1a


